### PR TITLE
 🐛 rename addon as the latest version of minishift requires the folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 [Install minishift](https://docs.openshift.org/latest/minishift/getting-started/installing.html)  
 [Install OC](https://docs.openshift.org/latest/cli_reference/get_started_cli.html#installing-the-cli)
 
+MiniShift needs to be at least 1.11.0, check it using the following command:
+```
+$ minishift version
+minishift v1.11.0+4459917
+```
+
 Enable minishift experimental addons:
 ```
 export MINISHIFT_ENABLE_EXPERIMENTAL=y
@@ -22,13 +28,6 @@ export DOCKERHUB_USERNAME=<docker hub username>
 export DOCKERHUB_PASSWORD=<docker hub password>
 export DOCKERHUB_ORG=<docker hub org, defaults to 'aerogearcatalog' if left unset>
 minishift config set addon-env DOCKERHUB_USERNAME=${DOCKERHUB_USERNAME},DOCKERHUB_PASSWORD="${DOCKERHUB_PASSWORD}",DOCKERHUB_ORG=${DOCKERHUB_ORG}
-```
-
-## Check MiniShift version
-MiniShift needs to be at least 1.11.0, check it using the following command:
-```
-$ minishift version
-minishift v1.11.0+4459917
 ```
 
 ## Configure MiniShift

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ export MINISHIFT_ENABLE_EXPERIMENTAL=y
 After Cloning this repo it will need to be added to the minishift addons catalog, this cannot be done from inside the directory, add it like so:
 ```
 cd ..
-minishift addon install -f minishift-mobilecore-addon/
-minishift addons enable mobilecore
+minishift addons install -f minishift-mobilecore-addon/
+minishift addons enable minishift-mobilecore-addon
 ```
 
 A few config values are required for this addon to function, as follows:
@@ -51,7 +51,7 @@ minishift start --openshift-version 3.7.0 --service-catalog
 
 If you did not enable the addon, you will need to apply it manually:
 ```
-minishift addons apply mobilecore
+minishift addons apply minishift-mobilecore-addon
 ```
 
 ## Troubleshooting
@@ -116,7 +116,7 @@ This can be caused if you have tried to execute `minishift delete` before execut
 ```
 sudo rm -rf ~/.minishift
 minishift addons install -f /path/to/minishift-mobilecore-addon
-minishift addons enable mobilecore
+minishift addons enable minishift-mobilecore-addon
 ```
 
 ### When All Else Fails

--- a/mobile-core.addon
+++ b/mobile-core.addon
@@ -1,4 +1,4 @@
-# Name: mobilecore                                                                          
+# Name: minishift-mobilecore-addon                                                                          
 # Description: Allows authenticated users to run images under a non pre-allocated UID   
 # Var-Defaults: DOCKERHUB_USERNAME=USERNAME,DOCKERHUB_PASSWORD=PASSWORD,DOCKERHUB_ORG=aerogearcatalog, VER=v9.3.0
 # OpenShift-Version: >=3.7.0


### PR DESCRIPTION
 name and add on name matches. Also update the Readme file to make sure
 the required minishift version is listed first

ping @philbrookes. Come across some problem when I tried it with the latest version of minishift.