### PR TITLE
allow configurable openshift-web-console image

### DIFF
--- a/docs/create-custom-console-container.adoc
+++ b/docs/create-custom-console-container.adoc
@@ -1,0 +1,25 @@
+:org: AeroGear
+//source: https://github.com/aerogear/minishift-mobilecore-addon/blob/master/README.md
+
+
+[[creating-custom-console-container]]
+= Creating Custom Console Container
+
+== Requirements
+```sh
+go get github.com/openshift/origin-web-console-server
+```
+
+== Steps
+First of all, in the origin-web-console repo, check out the code you wish to build an image for, and perform the link:https://github.com/openshift/origin-web-console#production-builds[required steps] to create an upto date `dist` directory.
+
+In the origin-web-console-server repo, run:
+```sh
+CONSOLE_REPO_PATH=path/to/origin-web-console make vendor-console
+make clean build
+OS_BUILD_ENV_PRESERVE=_output/local/bin hack/env make build-images
+docker tag openshift/origin-web-console:latest <YOUR_TAG_FOR_THIS_IMAGE>
+docker push <YOUR_TAG_FOR_THIS_IMAGE>
+```
+
+Now you are ready to start Minishift with the custom container

--- a/docs/minishift_install.adoc
+++ b/docs/minishift_install.adoc
@@ -61,6 +61,7 @@ Other options include:
 * CONTAINER_REPO_ORG: defaults to 'aerogearcatalog', specifies where to search for service catalog items.
 * CORE_REPO: defaults to 'aerogear', specifies the organziation or user in github to install the mobile-core component, that is, https://github.com/<CORE_REPO>/mobile-core.git.
 * CORE_BRANCH defaults to 'master', specifies the branch in the the CORE_REPO to install.
+* CONSOLE_IMAGE defaults to 'openshift/origin-web-console:v3.9.0', change this to specify a particular image to use for running the console.
 
 . Configure Minishift resources
 +
@@ -171,7 +172,7 @@ oc login -u system:admin
 oc get pods -n ansible-service-broker
 ----
 +
-If the asb pos is running correctly, you see something similar to the following:
+If the asb pod is running correctly, you see something similar to the following:
 +
 [source,bash]
 ----

--- a/mobile-core.addon
+++ b/mobile-core.addon
@@ -1,6 +1,6 @@
 # Name: minishift-mobilecore-addon                                                                          
 # Description: Allows authenticated users to run images under a non pre-allocated UID   
-# Var-Defaults: CONTAINER_REPO_USERNAME=USERNAME, CONTAINER_REPO_PASSWORD=PASSWORD, CONTAINER_REPO_ORG=aerogearcatalog, VER=v9.3.0, CORE_REPO=aerogear, CORE_BRANCH=master, CONSOLE_REPO=aerogear, CONSOLE_BRANCH=master
+# Var-Defaults: CONTAINER_REPO_USERNAME=USERNAME, CONTAINER_REPO_PASSWORD=PASSWORD, CONTAINER_REPO_ORG=aerogearcatalog, CORE_REPO=aerogear, CORE_BRANCH=master, CONSOLE_IMAGE=openshift/origin-web-console:v3.9.0
 # OpenShift-Version: >=3.9.0
 
 echo Installing oc client in vm
@@ -13,6 +13,7 @@ ssh tar -xf openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz && s
 ssh mkdir ~/.kube
 ssh cp /var/lib/minishift/openshift.local.config/master/admin.kubeconfig ~/.kube/config
 ssh oc login -u system:admin
+ssh oc adm policy add-cluster-role-to-user cluster-admin developer
 
 echo Installing mobile-client CRD: repo=#{CORE_REPO} branch=#{CORE_BRANCH}
 echo
@@ -26,7 +27,12 @@ echo Installing Ansible Service Broker: repo=#{CORE_REPO},branch=#{CORE_BRANCH},
 echo
 ssh curl -s -O -J -L https://raw.githubusercontent.com/#{CORE_REPO}/mobile-core/#{CORE_BRANCH}~/installer/roles/ansible-service-broker-setup/files/provision-ansible-service-broker.sh
 ssh chmod +x ./provision-ansible-service-broker.sh && ./provision-ansible-service-broker.sh '#{CONTAINER_REPO_USERNAME}' '#{CONTAINER_REPO_PASSWORD}' '#{CONTAINER_REPO_ORG}' true latest #{ip} nip.io ansible-service-broker
-ssh while [ $(oc get pods -n ansible-service-broker | grep "asb-" | grep -v "deploy" | grep "Running" | wc -l) -eq 0 ]; do sleep 10; done
+ssh while [ $(oc get pods -n ansible-service-broker | grep "asb-" | grep -v "deploy" | grep "Running" | wc -l) -eq 0 ]; do sleep 2; done
+
+echo Deploying web console image: #{CONSOLE_IMAGE}
+echo
+oc patch deployment webconsole -n openshift-web-console -p '{"spec": {"template": {"spec": {"containers": [{"name": "webconsole", "image": "#{CONSOLE_IMAGE}"}]}}}}'
+ssh while [ $(oc get pods -n openshift-web-console | grep "webconsole" | grep -v "deploy" | grep "Running" | wc -l) -eq 0 ]; do sleep 2; done
 
 echo Mobile Core successfully enabled
 echo

--- a/mobile-core.addon
+++ b/mobile-core.addon
@@ -32,7 +32,7 @@ ssh while [ $(oc get pods -n ansible-service-broker | grep "asb-" | grep -v "dep
 echo Deploying web console image: #{CONSOLE_IMAGE}
 echo
 ssh if [ '#{CONSOLE_IMAGE}' != 'openshift/origin-web-console:v3.9.0' ]; then oc patch deployment webconsole -n openshift-web-console -p '{"spec": {"template": {"spec": {"containers": [{"name": "webconsole", "image": "#{CONSOLE_IMAGE}"}]}}}}'; fi
-ssh while [ $(oc get pods -n openshift-web-console | grep "webconsole" | grep -v "deploy" | grep "Running" | wc -l) -eq 0 ]; do sleep 2; done
+ssh while [ $(oc get pods -n openshift-web-console -l app=openshift-web-console --template "{{(index .items 0).status.phase}}"  | grep Running | wc -l) -eq 0 ]; do sleep 2; done
 
 echo Mobile Core successfully enabled
 echo

--- a/mobile-core.addon
+++ b/mobile-core.addon
@@ -31,7 +31,7 @@ ssh while [ $(oc get pods -n ansible-service-broker | grep "asb-" | grep -v "dep
 
 echo Deploying web console image: #{CONSOLE_IMAGE}
 echo
-oc patch deployment webconsole -n openshift-web-console -p '{"spec": {"template": {"spec": {"containers": [{"name": "webconsole", "image": "#{CONSOLE_IMAGE}"}]}}}}'
+ssh if [ '#{CONSOLE_IMAGE}' != 'openshift/origin-web-console:v3.9.0' ]; then oc patch deployment webconsole -n openshift-web-console -p '{"spec": {"template": {"spec": {"containers": [{"name": "webconsole", "image": "#{CONSOLE_IMAGE}"}]}}}}'; fi
 ssh while [ $(oc get pods -n openshift-web-console | grep "webconsole" | grep -v "deploy" | grep "Running" | wc -l) -eq 0 ]; do sleep 2; done
 
 echo Mobile Core successfully enabled


### PR DESCRIPTION
Deploy custom web-console image.

## Verification steps:
1) Install this version of the addon into minishift and enable it.
2) reconfigure minishift addon-env
```
minishift config set addon-env CONTAINER_REPO_USERNAME=${DOCKERHUB_USER},CONTAINER_REPO_PASSWORD="${DOCKERHUB_PASSWORD}",CONSOLE_IMAGE=aerogear/origin-web-console:integrations
```
3) recreate minishift
```
minishift stop
minishift delete
minishift start --openshift-version v3.9.0 --service-catalog
```
4)
Deploy fh-sync-server to a project and you should see the integrations section in the overview once fh-sync-server has successfully deployed.
