### PR TITLE
Fixed directory and permissions error

### DIFF
--- a/mobile-core.addon
+++ b/mobile-core.addon
@@ -8,9 +8,10 @@ echo
 ssh tce-load -wi bash.tcz
 ssh tce-load -wi coreutils.tcz
 ssh sudo chmod -R a+rwx /var/lib/minishift/openshift.local.config
-ssh curl -s -O -J -L https://github.com/openshift/origin/releases/download/v3.9.0/openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz
-ssh tar -xf openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz && sudo cp openshift-origin-client-tools-v3.9.0-191fece-linux-64bit/oc /usr/bin/oc
-ssh mkdir ~/.kube
+ssh rm -f /tmp/openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz
+ssh cd /tmp && curl -s -O -J -L https://github.com/openshift/origin/releases/download/v3.9.0/openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz
+ssh cd /tmp && sudo tar -xf openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz && sudo cp openshift-origin-client-tools-v3.9.0-191fece-linux-64bit/oc /usr/bin/oc
+ssh mkdir -p ~/.kube
 ssh cp /var/lib/minishift/openshift.local.config/master/admin.kubeconfig ~/.kube/config
 ssh oc login -u system:admin
 ssh oc adm policy add-cluster-role-to-user cluster-admin developer


### PR DESCRIPTION
Fixed bugs:
- Consistently failing saying ~/.kube already existing
- Consistently failing for permissions error when downloading openshift
- If openshift was partially downloaded, the script didn't work anymore